### PR TITLE
bug fix for issue #6, upgrading wxMidi

### DIFF
--- a/samples/midisound/midisound.cpp
+++ b/samples/midisound/midisound.cpp
@@ -305,9 +305,8 @@ enum {
 };
 
 //Define a new event to poll MIDI input
-DECLARE_EVENT_TYPE(wxEVT_POLLING_EVENT, -1)
-
-DEFINE_EVENT_TYPE(wxEVT_POLLING_EVENT)
+//wxDECLARE_EVENT(wxEVT_POLLING_EVENT, wxCommandEvent); // Dclaration. For the header file. Not needed here, since it's a source file.
+wxDEFINE_EVENT(wxEVT_POLLING_EVENT, wxCommandEvent);    // Definition. For the source file.
 
 
 

--- a/samples/midisound/midisound.cpp
+++ b/samples/midisound/midisound.cpp
@@ -570,7 +570,7 @@ MyPanel::MyPanel( wxFrame *frame, int x, int y, int w, int h )
 
 	m_btCrash = new wxButton(panel, ID_CRASH, _T("Crash program"),
 									wxPoint(30,30), wxSize(140,25) );
-    pPanel4Sizer->Add(m_btCrash, 0, wxALL, 10 );
+    pPanel5Sizer->Add(m_btCrash, 0, wxALL, 10 );
 
     m_book->AddPage(panel, _("Crash test"), false);
 

--- a/src/wxMidi.cpp
+++ b/src/wxMidi.cpp
@@ -31,7 +31,7 @@
 wxMidiTimestamp wxMidiGetTime() { return Pt_Time(); }
 
 //Define the new command event to inform that MIDI input data is available
-DEFINE_EVENT_TYPE(wxEVT_MIDI_INPUT)
+wxDEFINE_EVENT(wxEVT_MIDI_INPUT, wxCommandEvent);
 
 //================================================================================
 // Implementation of classes wxMidiPmEvent, wxMidiShortEvent and wxMidiSysExEvent

--- a/src/wxMidi.cpp
+++ b/src/wxMidi.cpp
@@ -574,6 +574,8 @@ wxMidiError wxMidiInDevice::StartListening(wxWindow* pWindow, unsigned long nPol
 
 wxMidiError wxMidiInDevice::StopListening()
 {
+    if (m_pThread == nullptr) return wxMIDI_ERROR_BadPtr;
+
 	//stop the thread and wait for its termination
 	m_pThread->Delete();
 	delete m_pThread;

--- a/src/wxMidi.h
+++ b/src/wxMidi.h
@@ -230,7 +230,7 @@ enum wxMidiFilter
 /// Event wxEVT_MIDI_INPUT is a command event triggered when a new MIDI message is available
 /// to be read. This event is only triggered if the user application has called method
 /// wxMidiInDevice::StartListening().
-DECLARE_EVENT_TYPE(wxEVT_MIDI_INPUT, -1)
+wxDECLARE_EVENT(wxEVT_MIDI_INPUT, wxCommandEvent);
 
 /// Identifies the MIDI message type
 enum wxMidiMsgType

--- a/src/wxMidi.h
+++ b/src/wxMidi.h
@@ -1,3 +1,6 @@
+#ifndef __WXMIDI_H__		//to avoid nested includes
+#define __WXMIDI_H__
+
 //=====================================================================================
 // wxMidi: A MIDI interface based on PortMidi, the Portable Real-Time MIDI Library
 // --------------------------------------------------------------------------------
@@ -12,9 +15,6 @@
 #ifdef __GNUG__
 #pragma interface "wxMidi.cpp"
 #endif
-
-#ifndef __WXMIDI_H__		//to avoid nested includes
-#define __WXMIDI_H__
 
 // For compilers that support precompilation, includes "wx/wx.h".
 #include "wx/wxprec.h"


### PR DESCRIPTION
Hi Cecilios, 
Here come my changes as a Pull Request

Now, it builds and runs on Windows 10 using gcc 14.2/c++20 and wxWidgets 3.2

I've...
* updated the `DECLARE_EVENT_TYPE` and `DEFINE_EVENT_TYPE` to `wxDECLARE_EVENT` and `wxDEFINE_EVENT` in `wxMidi`
* fix the bug from your issue #6 in the midisound demo project

Thanks for sharing `wxMidi`. It really opened the world of handling MIDI, generating sound, for me